### PR TITLE
fix typo

### DIFF
--- a/src/tutorials/lang/QuickOverview.md
+++ b/src/tutorials/lang/QuickOverview.md
@@ -640,7 +640,7 @@ in
 
 ```nix
 concat = { a, b }: a + b  # 等价于 concat = x: x.a + x.b
-concat { a = "Hello"; b = "NixOS"; }
+concat { a = "Hello "; b = "NixOS"; }
 ```
 
 输出：


### PR DESCRIPTION
补上了一个空格，以免让人误以为nix会乱加空格

（对了，我不是很懂“如果 a，b 没人用”啥意思）