### PR TITLE
doc : fix VirtualMachine.md

### DIFF
--- a/src/tutorials/installation/VirtualMachine.md
+++ b/src/tutorials/installation/VirtualMachine.md
@@ -182,7 +182,7 @@ vim /mnt/etc/nixos/configuration.nix
 {
     imports = [
         ./hardware-configuration.nix
-    ]
+    ];
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
   networking.networkmanager.enable = true;
@@ -196,8 +196,7 @@ vim /mnt/etc/nixos/configuration.nix
     vim
     alacritty
   ];
-  sound.enable = true;
-  hardware.pulseaudio.enable = true;
+
   nix.settings.substituters = [
     "https://mirrors.cernet.edu.cn/nix-channels/store"
   ];


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/blob/3eeff54780a1a8c73c82ca51987962b62bd4219e/nixos/doc/manual/release-notes/rl-2411.section.md#sound-options-removal-sec-release-2411-migration-sound

```
sound options removal {#sec-release-24.11-migration-sound}
```
缺少一个标点以及配置选项有部分有问题

 修复了一下配置文件，原因见上