### PR TITLE
Remove unavailable link

### DIFF
--- a/src/.vuepress/config.ts
+++ b/src/.vuepress/config.ts
@@ -11,7 +11,7 @@ export default defineUserConfig({
   locales: {
     "/": {
       lang: "zh-CN",
-      title: "NixOS 中文 （狗子部署的）",
+      title: "NixOS 中文",
       description: "由 NixOS-CN 社区驱动",
     },
   },

--- a/src/.vuepress/config.ts
+++ b/src/.vuepress/config.ts
@@ -11,7 +11,7 @@ export default defineUserConfig({
   locales: {
     "/": {
       lang: "zh-CN",
-      title: "NixOS 中文",
+      title: "NixOS 中文 （狗子部署的）",
       description: "由 NixOS-CN 社区驱动",
     },
   },

--- a/src/README.md
+++ b/src/README.md
@@ -17,7 +17,6 @@ features:
   - title: 声明式配置
     icon: code
     details: 声明式配置系统，方便配置管理和可重复性构建
-    link: /guide/lang
 
   - title: 依赖管理
     icon: relation


### PR DESCRIPTION
The URL appears to be inconsistent with the actual document directory, and I couldn't find the corresponding content. The other three feature cards do not point to any URL, so I assume this is a legacy issue.